### PR TITLE
>4 switch states

### DIFF
--- a/lib/mapdescriptor.h
+++ b/lib/mapdescriptor.h
@@ -70,7 +70,7 @@ struct MapDescriptor {
     quint32 salaryIncrement = 0;
     quint32 maxDiceRoll = 0;
     std::array<bool, 128> ventureCards = {false};
-    std::array<QString, 4> frbFiles;
+    std::vector<QString> frbFiles;
     std::vector<OriginPoint> switchRotationOrigins;
     BoardTheme theme = Mario;
     QString background;

--- a/lib/mods/dolio/arbitrarynumswitchstates.cpp
+++ b/lib/mods/dolio/arbitrarynumswitchstates.cpp
@@ -8,6 +8,7 @@ void ArbitraryNumSwitchStates::readAsm(QDataStream &stream, const AddressMapper 
 
 void ArbitraryNumSwitchStates::writeAsm(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors)
 {
+    // Allow switch button district/destination ID to handle # of states other than 2 or 4
     stream.device()->seek(addressMapper.boomToFileAddress(0x8007f120));
 
     // cmpwi r4, 4 -> cmpwi r4, 0
@@ -18,4 +19,8 @@ void ArbitraryNumSwitchStates::writeAsm(QDataStream &stream, const AddressMapper
     stream.skipRawData(4);
     // li r5, 4 -> li r5, 2
     stream << PowerPcAsm::li(5, 2);
+
+
+    // Allow >4 states
+    // TODO add implementation of this
 }

--- a/lib/mods/dolio/arbitrarynumswitchstates.cpp
+++ b/lib/mods/dolio/arbitrarynumswitchstates.cpp
@@ -34,5 +34,72 @@ void ArbitraryNumSwitchStates::writeAsm(QDataStream &stream, const AddressMapper
     stream << PowerPcAsm::li(5, 2);
 
     // Allow >4 states
-    // TODO add implementation of this
+    size_t maxStates = 0;
+    for (auto &descriptor: mapDescriptors) {
+        maxStates = qMax(maxStates, descriptor.frbFiles.size());
+    }
+    quint32 newMapDataArrayAddr = allocate(QByteArray(4 * maxStates, '\0'), "Map Data Array", false);
+    auto newMapDataArrayPair = PowerPcAsm::make16bitValuePair(newMapDataArrayAddr);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007dde8));
+    // r3 <- &s_map_data_array -> r3 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(3, newMapDataArrayPair.upper);
+    stream.skipRawData(4);
+    stream << PowerPcAsm::addi(3, 3, newMapDataArrayPair.lower);
+    stream.skipRawData(4);
+    // li r5, 10 -> li r5, 4*maxStates
+    stream << PowerPcAsm::li(5, 4 * maxStates);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007e048));
+    // r3 <- &s_map_data_array -> r3 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(3, newMapDataArrayPair.upper);
+    stream.skipRawData(4);
+    stream << PowerPcAsm::addi(3, 3, newMapDataArrayPair.lower);
+    stream.skipRawData(4);
+    // li r5, 10 -> li r5, 4*maxStates
+    stream << PowerPcAsm::li(5, 4 * maxStates);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007e0d4));
+    // r3 <- &s_map_data_array -> r3 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(28, newMapDataArrayPair.upper);
+    stream.skipRawData(4);
+    stream << PowerPcAsm::addi(3, 28, newMapDataArrayPair.lower);
+    stream.skipRawData(4);
+    // li r5, 10 -> li r5, 4*maxStates
+    stream << PowerPcAsm::li(5, 4 * maxStates);
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007e108));
+    // s_map_data_array <- r0 -> *newMapDataArrayAddr <- r0
+    stream << PowerPcAsm::stw(0, newMapDataArrayPair.lower, 28);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007e480));
+    // r3 <- &s_map_data_array -> r3 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(3, newMapDataArrayPair.upper);
+    stream.skipRawData(4);
+    stream << PowerPcAsm::addi(3, 3, newMapDataArrayPair.lower);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007f138));
+    // r4 <- &s_map_data_array -> r4 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(4, newMapDataArrayPair.upper);
+    stream.skipRawData(8);
+    stream << PowerPcAsm::addi(4, 4, newMapDataArrayPair.lower);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007f18c));
+    // r4 <- &s_map_data_array -> r4 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(4, newMapDataArrayPair.upper);
+    stream.skipRawData(12);
+    stream << PowerPcAsm::addi(4, 4, newMapDataArrayPair.lower);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007f5bc));
+    // r4 <- &s_map_data_array -> r4 <- newMapDataArrayAddr
+    stream << PowerPcAsm::lis(4, newMapDataArrayPair.upper);
+    stream.skipRawData(8);
+    stream << PowerPcAsm::addi(4, 4, newMapDataArrayPair.lower);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x800cccc8));
+    // cmpwi cr1, r17, 0x4 -> cmpwi cr1, r17, 0x7FFF
+    stream << PowerPcAsm::cmpwi(17, 0x7FFF, 1);
+
+    stream.device()->seek(addressMapper.boomToFileAddress(0x800cefb4));
+    // cmpwi r29, 0x4 -> cmpwi r29, 0x7FFF
+    stream << PowerPcAsm::cmpwi(29, 0x7FFF);
 }

--- a/lib/mods/dolio/arbitrarynumswitchstates.cpp
+++ b/lib/mods/dolio/arbitrarynumswitchstates.cpp
@@ -9,6 +9,8 @@ void ArbitraryNumSwitchStates::readAsm(QDataStream &stream, const AddressMapper 
 void ArbitraryNumSwitchStates::writeAsm(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors)
 {
     // Allow switch button district/destination ID to handle # of states other than 2 or 4
+
+    // StopSwitch
     stream.device()->seek(addressMapper.boomToFileAddress(0x8007f120));
 
     // cmpwi r4, 4 -> cmpwi r4, 0
@@ -20,6 +22,16 @@ void ArbitraryNumSwitchStates::writeAsm(QDataStream &stream, const AddressMapper
     // li r5, 4 -> li r5, 2
     stream << PowerPcAsm::li(5, 2);
 
+    // StopPlace
+    stream.device()->seek(addressMapper.boomToFileAddress(0x8007f5a0));
+    // li r5, 2 -> mr r5, r0
+    stream << PowerPcAsm::mr(5, 0);
+    stream.skipRawData(4);
+    // cmpwi r0, 4 -> cmpwi r0, 0
+    stream << PowerPcAsm::cmpwi(0, 0);
+    stream.skipRawData(8);
+    // mr r5, r7 -> li r5, 2
+    stream << PowerPcAsm::li(5, 2);
 
     // Allow >4 states
     // TODO add implementation of this

--- a/lib/mods/dolio/arbitrarynumswitchstates.cpp
+++ b/lib/mods/dolio/arbitrarynumswitchstates.cpp
@@ -118,8 +118,8 @@ void ArbitraryNumSwitchStates::moveMapDataArray(QDataStream &stream, const Addre
 void ArbitraryNumSwitchStates::increaseGameManagerStorage(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors, size_t maxStates)
 {
     stream.device()->seek(addressMapper.boomToFileAddress(0x80016e88));
-    // li r3, 0x4f8 -> li r3, (0x4f8 + 8*maxStates)
-    stream << PowerPcAsm::li(3, 0x4f8 + maxStates * 8);
+    // li r3, 0x4f8 -> li r3, (0x4f8 + 8*maxStates + 8)
+    stream << PowerPcAsm::li(3, 0x4f8 + maxStates * 8 + 8);
 
     stream.device()->seek(addressMapper.boomToFileAddress(0x800ccc64));
     stream << PowerPcAsm::lwz(0, 0x4f8, 4);

--- a/lib/mods/dolio/arbitrarynumswitchstates.h
+++ b/lib/mods/dolio/arbitrarynumswitchstates.h
@@ -11,6 +11,10 @@ public:
     void readAsm(QDataStream &stream, const AddressMapper &addressMapper, std::vector<MapDescriptor> &mapDescriptors) override;
 protected:
     void writeAsm(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors) override;
+private:
+    void support3State(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors);
+    void moveMapDataArray(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors, size_t maxStates);
+    void increaseGameManagerStorage(QDataStream &stream, const AddressMapper &addressMapper, const std::vector<MapDescriptor> &mapDescriptors, size_t maxStates);
 };
 
 #endif // ARBITRARYNUMSWITCHSTATES_H

--- a/lib/mods/dolio/frbmaptable.cpp
+++ b/lib/mods/dolio/frbmaptable.cpp
@@ -9,6 +9,7 @@ quint32 FrbMapTable::writeTable(const std::vector<MapDescriptor> &descriptors) {
         for (auto &frbFile: descriptor.frbFiles) {
             subTable.append(allocate(frbFile));
         }
+        subTable.append(0);
         table.append(allocate(subTable, "FrbMapSubTable"));
     }
     return allocate(table, "FrbMapTable");

--- a/lib/mods/dolio/frbmaptable.cpp
+++ b/lib/mods/dolio/frbmaptable.cpp
@@ -4,9 +4,12 @@
 quint32 FrbMapTable::writeTable(const std::vector<MapDescriptor> &descriptors) {
     QVector<quint32> table;
     for (auto &descriptor: descriptors) {
+        QVector<quint32> subTable;
+        subTable.append(descriptor.frbFiles.size());
         for (auto &frbFile: descriptor.frbFiles) {
-            table.append(allocate(frbFile));
+            subTable.append(allocate(frbFile));
         }
+        table.append(allocate(subTable, "FrbMapSubTable"));
     }
     return allocate(table, "FrbMapTable");
 }
@@ -16,28 +19,36 @@ void FrbMapTable::writeAsm(QDataStream &stream, const AddressMapper &addressMapp
     PowerPcAsm::Pair16Bit v = PowerPcAsm::make16bitValuePair(tableAddr);
 
     // --- Game::GetMapFrbName ---
-    // mulli r3,r3,0x38  ->  mulli r3,r3,0x10
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccab0)); stream << PowerPcAsm::mulli(3, 3, 0x10);
-    // r5 <- 0x80428e50  ->  r5 <- tableAddr
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccab4)); stream << PowerPcAsm::lis(5, v.upper);
-    stream.skipRawData(0x4); stream << PowerPcAsm::addi(5, 5, v.lower);
-    // lwz r3,0x18(r3)   ->  lwz r3,0x0(r3)
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccac8)); stream << PowerPcAsm::lwz(3, 0x0, 3);
+    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccab0));
+    // [0x801ccab0] r3 *= 4
+    stream << PowerPcAsm::mulli(3, 3, 0x4);
+    // [0x801ccab4, 0x801ccab8] r5 <- tableAddr
+    stream << PowerPcAsm::lis(5, v.upper);
+    stream << PowerPcAsm::addi(5, 5, v.lower);
+    // [0x801ccabc] r5 <- r5[r3]
+    stream << PowerPcAsm::lwzx(5, 5, 3);
+    // [0x801ccac0] r4 *= 4
+    stream << PowerPcAsm::mulli(4, 4, 0x4);
+    // [0x801ccac4] r5 += 4
+    stream << PowerPcAsm::addi(5, 5, 0x4);
+    // [0x801ccac8] r3 <- r5[r4]
+    stream << PowerPcAsm::lwzx(3, 5, 4);
+    // [0x801ccacc] return
+    stream << PowerPcAsm::blr();
 
     // --- Game::GetMapMapNum ---
-    // mulli r0,r3,0x38  ->  mulli r0,r3,0x10
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccad0)); stream << PowerPcAsm::mulli(0, 3, 0x10);
-    // r4 <- 0x80428e50  ->  r4 <- tableAddr
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccad4)); stream << PowerPcAsm::lis(4, v.upper);
-    stream.skipRawData(0x4); stream << PowerPcAsm::addi(4, 4, v.lower);
-    // lwz r0,0x18(r4)   ->  lwz r0,0x0(r4)
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccae4)); stream << PowerPcAsm::lwz(0, 0x0, 4);
-    // lwz r0,0x1c(r4)   ->  lwz r0,0x4(r4)
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccaf0)); stream << PowerPcAsm::lwz(0, 0x4, 4);
-    // lwz r0,0x20(r4)   ->  lwz r0,0x8(r4)
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccb00)); stream << PowerPcAsm::lwz(0, 0x8, 4);
-    // lwz r0,0x24(r4)   ->  lwz r0,0xc(r4)
-    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccb10)); stream << PowerPcAsm::lwz(0, 0xc, 4);
+    stream.device()->seek(addressMapper.boomToFileAddress(0x801ccad0));
+    // [0x801ccad0] r3 <- r3 * 4
+    stream << PowerPcAsm::mulli(3, 3, 0x4);
+    // [0x801ccad4, 0x801ccad8] r4 <- tableAddr
+    stream << PowerPcAsm::lis(4, v.upper);
+    stream << PowerPcAsm::addi(4, 4, v.lower);
+    // [0x801ccadc] r4 <- r4[r3]
+    stream << PowerPcAsm::lwzx(4, 4, 3);
+    // [0x801ccae0] r3 <- r4[0]
+    stream << PowerPcAsm::lwz(3, 0x0, 4);
+    // [0x801ccae4] return
+    stream << PowerPcAsm::blr();
 }
 
 void FrbMapTable::readAsm(QDataStream &stream, std::vector<MapDescriptor> &mapDescriptors, const AddressMapper &addressMapper, bool isVanilla) {
@@ -45,23 +56,45 @@ void FrbMapTable::readAsm(QDataStream &stream, std::vector<MapDescriptor> &mapDe
         stream.skipRawData(0x18);
     }
     for (auto &mapDescriptor: mapDescriptors) {
-        for (auto &frbFile: mapDescriptor.frbFiles) {
-            quint32 addr;
-            stream >> addr;
-            frbFile = resolveAddressToString(addr, stream, addressMapper);
-        }
+        mapDescriptor.frbFiles.clear();
+
         if (isVanilla) {
+            for (int i=0; i<4; ++i) {
+                quint32 addr;
+                stream >> addr;
+                auto frbFile = resolveAddressToString(addr, stream, addressMapper);
+                if (!frbFile.isEmpty()) mapDescriptor.frbFiles.push_back(resolveAddressToString(addr, stream, addressMapper));
+            }
+
             // in vanilla main.dol the table has other stuff in it like bgm id, map frb files, etc.
             // this we need to skip to go the next target amount in the table
             stream.skipRawData(0x38 - 0x10);
+        } else {
+            quint32 subTableAddr;
+            stream >> subTableAddr;
+            auto posToReturnTo = stream.device()->pos();
+            stream.device()->seek(addressMapper.toFileAddress(subTableAddr));
+            quint32 numFrbFiles;
+            stream >> numFrbFiles;
+            for (int i=0; i<numFrbFiles; ++i) {
+                quint32 addr;
+                stream >> addr;
+                auto frbFile = resolveAddressToString(addr, stream, addressMapper);
+                if (!frbFile.isEmpty()) mapDescriptor.frbFiles.push_back(resolveAddressToString(addr, stream, addressMapper));
+            }
+            stream.device()->seek(posToReturnTo);
         }
     }
 }
 
-quint32 FrbMapTable::readTableAddr(QDataStream &stream, const AddressMapper &addressMapper, bool) {
+quint32 FrbMapTable::readTableAddr(QDataStream &stream, const AddressMapper &addressMapper, bool isVanilla) {
     stream.device()->seek(addressMapper.boomToFileAddress(0x801ccab4));
-    quint32 lisOpcode, dummy, addiOpcode;
-    stream >> lisOpcode >> dummy >> addiOpcode;
+    quint32 lisOpcode, addiOpcode;
+    stream >> lisOpcode;
+    if (isVanilla) {
+        stream.skipRawData(4);
+    }
+    stream >> addiOpcode;
     return PowerPcAsm::make32bitValueFromPair(lisOpcode, addiOpcode);
 }
 

--- a/lib/powerpcasm.cpp
+++ b/lib/powerpcasm.cpp
@@ -131,8 +131,8 @@ quint32 bne(LabelTable &labels, QString label, const QVector<quint32> &asmListin
 }
 // -- blr --
 quint32 blr() { return blr_opcode; }
-quint32 cmpwi(quint8 reg, qint16 value) {
-    return cmpwi_opcode + ((quint32)reg << 16) + ((quint32)value & 0x0000FFFF);
+quint32 cmpwi(quint8 reg, qint16 value, quint8 cr) {
+    return cmpwi_opcode + ((quint32)cr << 23) + ((quint32)reg << 16) + ((quint32)value & 0x0000FFFF);
 }
 quint32 cmplwi(quint8 reg, quint16 value) {
     return cmplwi_opcode + ((quint32)reg << 16) + ((quint32)value & 0x0000FFFF);

--- a/lib/powerpcasm.h
+++ b/lib/powerpcasm.h
@@ -154,7 +154,7 @@ namespace PowerPcAsm {
     quint32 bne(int offset);
     quint32 bne(LabelTable &labels, QString label, const QVector<quint32> &asmListing);
     quint32 blr();
-    quint32 cmpwi(quint8 reg, qint16 value);
+    quint32 cmpwi(quint8 reg, qint16 value, quint8 cr = 0);
     quint32 cmplwi(quint8 reg, quint16 value);
     quint32 nop();
     quint32 mflr(quint8 reg);

--- a/lib/python/pythonbindings.cpp
+++ b/lib/python/pythonbindings.cpp
@@ -261,11 +261,11 @@ void init_pycsmm(pybind11::module_ &m) {
     bindStdArray<bool, 128>(m, "VentureCardTable", R"pycsmmdoc(
     A boolean array-like type such that venture card x is enabled iff VentureCardTable[x-1] is enabled.
 )pycsmmdoc");
-
+    /*
     bindStdArray<QString, 4>(m, "FrbFiles", R"pycsmmdoc(
     An array-like type containing the frb file names.
 )pycsmmdoc");
-
+    */
     pybind11::bind_vector<std::vector<OriginPoint>>(m, "OriginPoints", R"pycsmmdoc(
     A list-like type of switch rotation origins.
 )pycsmmdoc");

--- a/lib/python/pythonbindings.h
+++ b/lib/python/pythonbindings.h
@@ -263,7 +263,6 @@ struct MusicEntry;
 struct MapDescriptor;
 
 PYBIND11_MAKE_OPAQUE(std::array<bool, 128>);
-PYBIND11_MAKE_OPAQUE(std::array<QString, 4>);
 PYBIND11_MAKE_OPAQUE(std::vector<OriginPoint>);
 PYBIND11_MAKE_OPAQUE(std::vector<MusicEntry>);
 PYBIND11_MAKE_OPAQUE(std::map<MusicType, std::vector<MusicEntry>>);


### PR DESCRIPTION
Recommended practice now is to specify switch states as
```yaml
frbFiles:
- switch_music_test_0
- switch_music_test_1
- switch_music_test_2
- switch_music_test_3
- switch_music_test_4
```
However, the old way of specifying `frbFile1`, etc. is still supported.