### PR TITLE
Fix the Mac Build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -103,10 +103,14 @@ jobs:
         make html
         cd _build
         zip -r "csmm-$VERSION_NAME-pydocs.zip" html
+    
+    - name: Shut down XProtectBehaviorService, which interferes with macdeployqt
+      working-directory: ${{github.workspace}}
+      run: sudo pkill -9 XProtect >/dev/null
 
     - name: Deploy
       working-directory: ${{github.workspace}}
-      run: macdeployqt 'csmm.app' -dmg -verbose=3
+      run: macdeployqt 'csmm.app' -dmg
 
     - name: Rename
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    
+
     - name: Install dependencies
       run: |
         sudo apt-get install -y libyaml-cpp-dev libarchive-dev wget ninja-build libxkbcommon0 libxkbcommon-x11-0
@@ -27,13 +27,13 @@ jobs:
         chmod +x linuxdeploy-x86_64.AppImage
         wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
         chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
-    
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
         version: 5.15.2
         target: desktop
-    
+
     - name: Configure CMake
       working-directory: ${{github.workspace}}
       run: cmake -DCMAKE_BUILD_TYPE=Release . -G Ninja
@@ -41,30 +41,30 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}
       run: ninja
-    
+
     - name: Deploy
       run: |
         ./linuxdeploy-x86_64.AppImage --appdir=csmm-x86_64 -e csmm -d csmm.desktop -i AppIcon.png -p qt
         cp -r -t csmm-x86_64/usr/bin wit szs py csmmpython
         ARCH=x86_64 ./linuxdeploy-x86_64.AppImage --appdir=csmm-x86_64 -p qt -o appimage
         mv csmm*.AppImage csmm-$VERSION_NAME-linux.AppImage
-    
+
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: ${{github.workspace}}/csmm-${{github.event.release.tag_name}}-linux.AppImage
   macos:
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    
+
     - name: Symlink Python framework to desired location
       run: |
-        cmake -E make_directory /usr/local/opt/python@3.11/lib
-        ln -s /usr/local/Frameworks/Python.framework /usr/local/opt/python@3.11/lib/Python.framework
+        sudo mkdir /Library/lib
+        sudo ln -s /Library/Frameworks/Python.framework /Library/lib/Python.framework
 
     - name: Install dependencies
       run: |
@@ -85,17 +85,17 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}
       run: ninja
-    
+
     - name: Install Pip in CSMM
       working-directory: ${{github.workspace}}
       run: |
         wget https://bootstrap.pypa.io/get-pip.py
         csmm.app/Contents/MacOS/csmmpython get-pip.py
-    
+
     - name: Install Pip Modules In Embedded Python
       working-directory: ${{github.workspace}}
       run: csmm.app/Contents/MacOS/csmmpython -m pip install sphinx==5.0.2 pillow
-    
+
     - name: Build docs
       working-directory: ${{github.workspace}}/docs
       run: |
@@ -106,7 +106,7 @@ jobs:
 
     - name: Deploy
       working-directory: ${{github.workspace}}
-      run: macdeployqt 'csmm.app' -dmg
+      run: macdeployqt 'csmm.app' -dmg -verbose=3
 
     - name: Rename
       working-directory: ${{github.workspace}}
@@ -132,10 +132,10 @@ jobs:
         version: 5.15.2
         target: desktop
         arch: win64_msvc2019_64
-    
+
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
-    
+
     - name: Setup VS Environment
       uses: seanmiddleditch/gha-setup-vsdevenv@master
 
@@ -147,14 +147,14 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}
       run: ninja
-    
+
     - name: Install Pip in CSMM
       working-directory: ${{github.workspace}}
       shell: pwsh
       run: |
         Invoke-WebRequest -Uri https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
         ./csmmpython get-pip.py
-    
+
     - name: Install Pip Modules In Embedded Python
       working-directory: ${{github.workspace}}
       run: ./csmmpython -m pip install pillow
@@ -183,14 +183,14 @@ jobs:
         cp "C:\Program Files\OpenSSL\bin\libcrypto-1_1-x64.dll" "csmm-$VERSION_NAME"
         cp "C:\Program Files\OpenSSL\bin\libssl-1_1-x64.dll" "csmm-$VERSION_NAME"
         cp "C:/hostedtoolcache/windows/Python/$PYVER/x64/python$CONDENSEDPYVER.dll" "csmm-$VERSION_NAME"
-    
+
     - name: Copy Python stdlib
       working-directory: ${{github.workspace}}
       shell: bash
       run: |
         mkdir "csmm-$VERSION_NAME/py"
         cp -R "py/Lib" "csmm-$VERSION_NAME/py"
-    
+
     - name: Archive
       uses: thedoctor0/zip-release@main
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 add_compile_definitions(QT_NO_KEYWORDS)
 add_compile_definitions(UNICODE)
@@ -13,7 +13,7 @@ if(WIN32)
     add_definitions(/wd4267)
 endif()
 
-set(PROJECT_VERSION 6.3.1)
+set(PROJECT_VERSION 6.3.2)
 
 project(csmm VERSION ${PROJECT_VERSION} LANGUAGES CXX C)
 
@@ -256,7 +256,8 @@ file(MAKE_DIRECTORY ${PYTHON_STDLIB_DESTFOLDER})
 file(COPY "${Python_STDLIB}" DESTINATION ${PYTHON_STDLIB_DESTFOLDER}
     PATTERN "config-*/*" EXCLUDE
     PATTERN ".DS_Store" EXCLUDE
-    PATTERN "site-packages" EXCLUDE)
+    PATTERN "site-packages" EXCLUDE
+    PATTERN "test" EXCLUDE)
 
 if (WIN32)
     file(COPY "${Python_STDLIB}/../DLLs" DESTINATION ${PYTHON_STDLIB_DESTFOLDER})
@@ -344,12 +345,13 @@ target_compile_definitions(csmm PUBLIC CSMM_VERSION="${PROJECT_VERSION}")
 
 if(NOT WIN32)
     find_package(yaml-cpp REQUIRED)
-    if (NOT YAML_CPP_INCLUDE_DIR)
-        set(YAML_CPP_INCLUDE_DIR "/usr/local/include")
-    endif()
-    if (NOT YAML_CPP_LIBRARIES)
+
+    if(APPLE)
+        set(YAML_CPP_LIBRARIES "yaml-cpp::yaml-cpp")
+    else()
         set(YAML_CPP_LIBRARIES "yaml-cpp")
     endif()
+
     target_include_directories(csmm PRIVATE ${YAML_CPP_INCLUDE_DIR})
     target_link_libraries(csmm PRIVATE ${YAML_CPP_LIBRARIES})
     target_include_directories(csmmpython PRIVATE ${YAML_CPP_INCLUDE_DIR})


### PR DESCRIPTION
This PR makes some changes to both the GitHub Actions workflow and the `CMakeLists.txt` file to fix the issues that currently exist on Mac OS. Namely, with `yaml-cpp` not being found and with `python` not being properly embedded.

The `yaml-cpp` issue is one that has arisen from the Mac version needing a different namespace specified than on other platforms. The `python` issue is resolved by symlinking it where `macdeployqt` is expecting it to be.

The one other addition is the step to kill the `XProtectBehaviorService` which interferes with `macdeployqt`'s ability to create `.dmg` images.