### PR TITLE
Fix issue where Linux users cannot add boards individually

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -27,6 +27,8 @@ jobs:
         chmod +x linuxdeploy-x86_64.AppImage
         wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
         chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
+        sudo add-apt-repository universe
+        sudo apt install libfuse2
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -55,22 +57,14 @@ jobs:
       with:
         files: ${{github.workspace}}/csmm-${{github.event.release.tag_name}}-linux.AppImage
   macos:
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - name: Symlink Python framework to desired location
-      run: |
-        sudo mkdir /Library/lib
-        sudo ln -s /Library/Frameworks/Python.framework /Library/lib/Python.framework
-
     - name: Install dependencies
-      run: |
-        brew install libarchive
-        brew install yaml-cpp
-        brew install ninja
+      run: brew install libarchive ninja yaml-cpp
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -86,15 +80,21 @@ jobs:
       working-directory: ${{github.workspace}}
       run: ninja
 
+    - name: Configure Python virtual environment
+      working-directory: ${{github.workspace}}
+      run: |
+        python -m venv ./csmm-venv
+        source ./csmm-venv/bin/activate
+
     - name: Install Pip in CSMM
       working-directory: ${{github.workspace}}
       run: |
         wget https://bootstrap.pypa.io/get-pip.py
-        csmm.app/Contents/MacOS/csmmpython get-pip.py
+        ./csmm.app/Contents/MacOS/csmmpython -m get-pip --break-system-packages
 
     - name: Install Pip Modules In Embedded Python
       working-directory: ${{github.workspace}}
-      run: csmm.app/Contents/MacOS/csmmpython -m pip install sphinx==5.0.2 pillow
+      run: ./csmm.app/Contents/MacOS/csmmpython -m pip install sphinx==7.2.6 pillow==10.1.0 --break-system-packages
 
     - name: Build docs
       working-directory: ${{github.workspace}}/docs
@@ -103,14 +103,20 @@ jobs:
         make html
         cd _build
         zip -r "csmm-$VERSION_NAME-pydocs.zip" html
-    
+
     - name: Shut down XProtectBehaviorService, which interferes with macdeployqt
       working-directory: ${{github.workspace}}
-      run: sudo pkill -9 XProtect >/dev/null
+      run: |
+        echo killing...; sudo pkill -9 XProtect >/dev/null || true;
+        echo waiting...; while pgrep XProtect; do sleep 3; done;
 
     - name: Deploy
       working-directory: ${{github.workspace}}
-      run: macdeployqt 'csmm.app' -dmg
+      run: |
+        mkdir -p /usr/local/opt/python@3.12/lib/Python.framework/Versions/3.12/
+        sudo ln -s $HOMEBREW_PREFIX/opt/python@3.12/libexec/bin/ /usr/local/opt/python@3.12/lib/Python.framework/Versions/3.12/
+
+        sudo macdeployqt 'csmm.app' -dmg -verbose=3
 
     - name: Rename
       working-directory: ${{github.workspace}}
@@ -152,16 +158,23 @@ jobs:
       working-directory: ${{github.workspace}}
       run: ninja
 
+    - name: Configure Python virtual environment
+      working-directory: ${{github.workspace}}
+      run: |
+        py -m venv .venv
+        .\.venv\Scripts\activate
+
     - name: Install Pip in CSMM
       working-directory: ${{github.workspace}}
       shell: pwsh
       run: |
+        .\.venv\Scripts\activate
         Invoke-WebRequest -Uri https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-        ./csmmpython get-pip.py
+        .\.venv\Scripts\python -m get-pip --break-system-packages
 
     - name: Install Pip Modules In Embedded Python
       working-directory: ${{github.workspace}}
-      run: ./csmmpython -m pip install pillow
+      run: .\.venv\Scripts\pip install pillow==10.1.0 --break-system-packages
 
     - name: Rename
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
   linux:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -29,6 +29,11 @@ jobs:
         chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
         sudo add-apt-repository universe
         sudo apt install libfuse2
+
+    - name: Switch to Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -59,12 +64,12 @@ jobs:
   macos:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Install dependencies
-      run: brew install libarchive ninja yaml-cpp
+      run: brew install libarchive ninja python@3.12 yaml-cpp
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -79,6 +84,11 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}
       run: ninja
+
+    - name: Switch to Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
     - name: Configure Python virtual environment
       working-directory: ${{github.workspace}}
@@ -113,10 +123,11 @@ jobs:
     - name: Deploy
       working-directory: ${{github.workspace}}
       run: |
-        mkdir -p /usr/local/opt/python@3.12/lib/Python.framework/Versions/3.12/
-        sudo ln -s $HOMEBREW_PREFIX/opt/python@3.12/libexec/bin/ /usr/local/opt/python@3.12/lib/Python.framework/Versions/3.12/
-
-        sudo macdeployqt 'csmm.app' -dmg -verbose=3
+        HOMEBREW_PREFIX=$(brew --prefix python@3.12)
+        echo $HOMEBREW_PREFIX
+        mkdir -p $HOMEBREW_PREFIX/lib/Python.framework/
+        sudo cp -a $HOMEBREW_PREFIX/Frameworks/Python.framework/. $HOMEBREW_PREFIX/lib/Python.framework/
+        macdeployqt 'csmm.app' -dmg
 
     - name: Rename
       working-directory: ${{github.workspace}}
@@ -132,7 +143,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -158,6 +169,11 @@ jobs:
       working-directory: ${{github.workspace}}
       run: ninja
 
+    - name: Switch to Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
     - name: Configure Python virtual environment
       working-directory: ${{github.workspace}}
       run: |
@@ -170,11 +186,11 @@ jobs:
       run: |
         .\.venv\Scripts\activate
         Invoke-WebRequest -Uri https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-        .\.venv\Scripts\python -m get-pip --break-system-packages
+        .\csmmpython -m get-pip --break-system-packages
 
     - name: Install Pip Modules In Embedded Python
       working-directory: ${{github.workspace}}
-      run: .\.venv\Scripts\pip install pillow==10.1.0 --break-system-packages
+      run: .\csmmpython -m pip install pillow==10.1.0 --break-system-packages
 
     - name: Rename
       working-directory: ${{github.workspace}}
@@ -195,7 +211,7 @@ jobs:
       working-directory: ${{github.workspace}}
       shell: bash
       run: |
-        PYVER=$(python --version | sed 's/Python //')
+        PYVER=$(py --version | sed 's/Python //')
         CONDENSEDPYVER=$(echo $PYVER | sed 's/\([0-9]*\)\.\([0-9]*\).*/\1\2/')
         cp "C:\Program Files\OpenSSL\bin\libcrypto-1_1-x64.dll" "csmm-$VERSION_NAME"
         cp "C:\Program Files\OpenSSL\bin\libssl-1_1-x64.dll" "csmm-$VERSION_NAME"

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 	path = lib/pybind11
 	url = https://github.com/pybind/pybind11
 	ignore = dirty
+	branch = stable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(WIN32)
     add_definitions(/wd4267)
 endif()
 
-set(PROJECT_VERSION 6.3.2)
+set(PROJECT_VERSION 6.3.3)
 
 project(csmm VERSION ${PROJECT_VERSION} LANGUAGES CXX C)
 
@@ -285,11 +285,11 @@ if(APPLE)
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/wit
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/wit-v3.05a-r8638-mac ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/wit
     )
-    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.39a-r8904-mac64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
+    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.40a-r8917-mac64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/szs
-        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.39a-r8904-mac64 ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/szs
+        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.40a-r8917-mac64 ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/szs
     )
     add_custom_command(TARGET csmmpython POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/csmmpython ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/csmmpython
@@ -305,11 +305,11 @@ elseif(WIN32)
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/wit
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/wit-v3.05a-r8638-cygwin64 ${CMAKE_CURRENT_BINARY_DIR}/wit
     )
-    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.39a-r8904-cygwin64.zip ${CMAKE_CURRENT_BINARY_DIR}/szs.zip)
+    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.40a-r8917-cygwin64.zip ${CMAKE_CURRENT_BINARY_DIR}/szs.zip)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xf ${CMAKE_CURRENT_BINARY_DIR}/szs.zip
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/szs
-        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.39a-r8904-cygwin64 ${CMAKE_CURRENT_BINARY_DIR}/szs
+        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.40a-r8917-cygwin64 ${CMAKE_CURRENT_BINARY_DIR}/szs
     )
 else()
     add_executable(csmm ${MAIN_SOURCES})
@@ -321,11 +321,11 @@ else()
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/wit
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/wit-v3.05a-r8638-x86_64 ${CMAKE_CURRENT_BINARY_DIR}/wit
     )
-    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.39a-r8904-x86_64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
+    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.40a-r8917-x86_64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/szs
-        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.39a-r8904-x86_64 ${CMAKE_CURRENT_BINARY_DIR}/szs
+        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.40a-r8917-x86_64 ${CMAKE_CURRENT_BINARY_DIR}/szs
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,11 +284,11 @@ if(APPLE)
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/wit
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/wit-v3.05a-r8638-mac ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/wit
     )
-    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.33a-r8773-mac64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
+    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.39a-r8904-mac64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/szs
-        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.33a-r8773-mac64 ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/szs
+        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.39a-r8904-mac64 ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/szs
     )
     add_custom_command(TARGET csmmpython POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/csmmpython ${CMAKE_CURRENT_BINARY_DIR}/csmm.app/Contents/MacOS/csmmpython
@@ -304,11 +304,11 @@ elseif(WIN32)
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/wit
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/wit-v3.05a-r8638-cygwin64 ${CMAKE_CURRENT_BINARY_DIR}/wit
     )
-    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.33a-r8773-cygwin64.zip ${CMAKE_CURRENT_BINARY_DIR}/szs.zip)
+    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.39a-r8904-cygwin64.zip ${CMAKE_CURRENT_BINARY_DIR}/szs.zip)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xf ${CMAKE_CURRENT_BINARY_DIR}/szs.zip
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/szs
-        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.33a-r8773-cygwin64 ${CMAKE_CURRENT_BINARY_DIR}/szs
+        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.39a-r8904-cygwin64 ${CMAKE_CURRENT_BINARY_DIR}/szs
     )
 else()
     add_executable(csmm ${MAIN_SOURCES})
@@ -320,11 +320,11 @@ else()
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/wit
         COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/wit-v3.05a-r8638-x86_64 ${CMAKE_CURRENT_BINARY_DIR}/wit
     )
-    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.33a-r8773-x86_64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
+    file(DOWNLOAD https://szs.wiimm.de/download/szs-v2.39a-r8904-x86_64.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/szs.tar.gz
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_CURRENT_BINARY_DIR}/szs
-        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.33a-r8773-x86_64 ${CMAKE_CURRENT_BINARY_DIR}/szs
+        COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/szs-v2.39a-r8904-x86_64 ${CMAKE_CURRENT_BINARY_DIR}/szs
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ if(APPLE)
     add_executable(csmm MACOSX_BUNDLE ${MAIN_SOURCES} ${APP_ICON_MACOSX} ${PY_STDLIB_FILES})
     add_executable(csmmpython ${PY_SOURCES})
 
+
     file(DOWNLOAD https://wit.wiimm.de/download/wit-v3.05a-r8638-mac.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/wit.tar.gz)
     add_custom_command(TARGET csmm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/wit.tar.gz

--- a/mapdescriptorwidget.cpp
+++ b/mapdescriptorwidget.cpp
@@ -76,7 +76,7 @@ void MapDescriptorWidget::loadRowWithMapDescriptor(int row, const MapDescriptor 
 
     auto importYamlButton = new QPushButton("Import .yaml or .zip");
     connect(importYamlButton, &QPushButton::clicked, this, [=](bool) {
-        auto openYaml = QFileDialog::getOpenFileName(this, "Import .yaml or .zip", QString(), "Map Descriptor Files (*.yaml;*.zip)");
+        auto openYaml = QFileDialog::getOpenFileName(this, "Import .yaml or .zip", QString(), "Map Descriptor Files (*.yaml *.zip)");
         if (openYaml.isEmpty()) return;
         MapDescriptor newDescriptor;
         try {


### PR DESCRIPTION
This PR does two things:
* Updates the `szs` dependency from version `v2.33a-r8773` to the latest version, `v2.39a-r8904`, as the former does not seem to be available for download any longer.
* Fixes a bug present only in the Linux version that caused the dialog box for `Import .yaml or .zip` to always be empty.