### PR TITLE
Allow setting temporary directory alongside network cache directory, and greatly improve disk space error messaging

### DIFF
--- a/lib/importexportutils.cpp
+++ b/lib/importexportutils.cpp
@@ -121,7 +121,8 @@ void exportYaml(const QDir &dir, const QString &yamlFileDest, const MapDescripto
 static void importYamlZip(const QString &yamlZipSrc, MapDescriptor &descriptor, const QDir &importDir,
                           const std::function<void(double)> &progressCallback,
                           const QString &backgroundZipDir) {
-    QTemporaryDir intermediateDir;
+    QSettings settings;
+    QTemporaryDir intermediateDir(settings.value("temporaryDirectory","").toString() + "/intermediate");
     if (!intermediateDir.isValid()) {
         throw Exception("Could not create an intermediate directory");
     }

--- a/lib/mods/arc/defaultminimapicons.cpp
+++ b/lib/mods/arc/defaultminimapicons.cpp
@@ -31,8 +31,8 @@ QMap<QString, ArcFileInterface::ModifyArcFunction> DefaultMinimapIcons::modifyAr
         if (!uppercasedLocale.isEmpty()) {
             langDir = QString("lang%1/").arg(uppercasedLocale);
         }
-
-        auto minimapTemp = QSharedPointer<QTemporaryDir>::create();
+        QSettings settings;
+        auto minimapTemp = QSharedPointer<QTemporaryDir>::create(settings.value("temporaryDirectory","").toString() + "/minimap");
         if (!minimapTemp->isValid()) {
             throw ModException(QString("could not create temporary directory %1").arg(minimapTemp->path()));
         }

--- a/lib/mods/csmmmodpack.h
+++ b/lib/mods/csmmmodpack.h
@@ -256,9 +256,10 @@ public:
         QHash<QString, QMap<QString, ArcFileInterface::ModifyArcFunction>> arcModifiers;
         QHash<QString, QMap<QString, BrresFileInterface::ModifyBrresFunction>> brresModifiers;
         QMap<QString, UiMessage> messageFiles;
-        QTemporaryDir arcFilesDir;
+        QSettings settings;
+        QTemporaryDir arcFilesDir(settings.value("temporaryDirectory","").toString() + "/arc");
         QSet<QString> arcFiles;
-        QTemporaryDir brresFilesDir;
+        QTemporaryDir brresFilesDir(settings.value("temporaryDirectory","").toString() + "/brres");
         QSet<QString> brresFiles;
         if (!arcFilesDir.isValid()) {
             throw ModException(QString("error creating temporary directory: %1").arg(arcFilesDir.errorString()));

--- a/lib/mods/modloader.h
+++ b/lib/mods/modloader.h
@@ -10,13 +10,13 @@ namespace ModLoader {
  * Loads the mod lists in the files and aggregates them.
  * @return a pair containing (1) a list of mods and (2) temporary directories holding the modpacks if applicable
  */
-std::pair<ModListType, std::shared_ptr<QTemporaryDir[]>> importModpackCollection(const QVector<QString> &modlistColl);
+std::pair<ModListType, std::vector<std::shared_ptr<QTemporaryDir>>> importModpackCollection(const QVector<QString> &modlistColl, const std::vector<std::shared_ptr<QTemporaryDir>> tmpDirs);
 
 /**
  * Loads the mod list from the file, or the default modlist if file is an empty string.
  * @return a pair containing (1) a list of mods and (2) a temporary directory holding the modpack if applicable
  */
-std::pair<ModListType, std::shared_ptr<QTemporaryDir>> importModpackFile(const QString &file);
+std::pair<ModListType, std::shared_ptr<QTemporaryDir>> importModpackFile(const QString &file, const std::shared_ptr<QTemporaryDir> tmpDir);
 
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -122,6 +122,17 @@ int main(int argc, char *argv[])
         }
 #endif
         QSettings settings;
+        // configure the network cache and temporary directories if they are not present
+        if (!settings.contains("networkCacheDirectory") || !settings.value("networkCacheDirectory").isValid()) {
+            QDir applicationCacheDir(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
+            auto defaultNetworkCacheDir = applicationCacheDir.filePath("networkCache");
+            settings.setValue("networkCacheDirectory", defaultNetworkCacheDir);
+        }
+        if (!settings.contains("temporaryDirectory") || !settings.value("temporaryDirectory").isValid()) {
+            QTemporaryDir d;
+            settings.setValue("temporaryDirectory", d.path());
+            d.remove();
+        }
         QWidget *w;
         switch (settings.value("csmmMode", INDETERMINATE).toInt()) {
         case INDETERMINATE:

--- a/maincli.cpp
+++ b/maincli.cpp
@@ -202,8 +202,11 @@ void run(QStringList arguments)
                 if(!targetDir.exists()) {
                     targetDir.mkpath(".");
                 }
+                QSettings settings;
+                std::shared_ptr<QTemporaryDir> tmpDir = std::make_shared<QTemporaryDir>(settings.value("temporaryDirectory","").toString() + "/download");
+
                 auto gameInstance = GameInstance::fromGameDirectory(sourceDir.path(), "");
-                auto mods = ModLoader::importModpackFile(parser.value(modPackOption));
+                auto mods = ModLoader::importModpackFile(parser.value(modPackOption), tmpDir);
                 CSMMModpack modpack(gameInstance, mods.first.begin(), mods.first.end());
                 modpack.load(sourceDir.path());
                 auto descriptors = gameInstance.mapDescriptors();
@@ -284,7 +287,9 @@ void run(QStringList arguments)
                 QFile file(sourceDir.filePath("csmm_pending_changes.yaml"));
                 if(!file.exists()) {
                     auto gameInstance = GameInstance::fromGameDirectory(sourceDir.path(), "");
-                    auto mods = ModLoader::importModpackFile(parser.value(modPackOption));
+                    QSettings settings;
+                    std::shared_ptr<QTemporaryDir> tmpDir = std::make_shared<QTemporaryDir>(settings.value("temporaryDirectory","").toString() + "/download");
+                    auto mods = ModLoader::importModpackFile(parser.value(modPackOption), tmpDir);
                     CSMMModpack modpack(gameInstance, mods.first.begin(), mods.first.end());
                     modpack.load(sourceDir.path());
                     auto descriptors = gameInstance.mapDescriptors();
@@ -321,7 +326,9 @@ void run(QStringList arguments)
                     cout << Configuration::status(sourceDir.filePath("csmm_pending_changes.yaml"));
                 } else {
                     auto gameInstance = GameInstance::fromGameDirectory(sourceDir.path(), "");
-                    auto mods = ModLoader::importModpackFile(parser.value(modPackOption));
+                    QSettings settings;
+                    std::shared_ptr<QTemporaryDir> tmpDir = std::make_shared<QTemporaryDir>(settings.value("temporaryDirectory","").toString() + "/download");
+                    auto mods = ModLoader::importModpackFile(parser.value(modPackOption), tmpDir);
                     CSMMModpack modpack(gameInstance, mods.first.begin(), mods.first.end());
                     modpack.load(sourceDir.path());
                     auto descriptors = gameInstance.mapDescriptors();
@@ -362,7 +369,9 @@ void run(QStringList arguments)
                         exit(1);
                     }
                     auto gameInstance = GameInstance::fromGameDirectory(sourceDir.path(), importDir.path());
-                    auto mods = ModLoader::importModpackFile(parser.value(modPackOption));
+                    QSettings settings;
+                    std::shared_ptr<QTemporaryDir> tmpDir = std::make_shared<QTemporaryDir>(settings.value("temporaryDirectory","").toString() + "/download");
+                    auto mods = ModLoader::importModpackFile(parser.value(modPackOption), tmpDir);
                     CSMMModpack modpack(gameInstance, mods.first.begin(), mods.first.end());
                     modpack.load(sourceDir.path());
                     auto &descriptors = gameInstance.mapDescriptors();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -29,8 +29,7 @@ private:
     QSharedPointer<QTemporaryDir> importDir;
 
     ModListType modList;
-    std::shared_ptr<QTemporaryDir[]> tempModpackDirs;
-
+    std::vector<std::shared_ptr<QTemporaryDir>> tempModpackDirs;
 
     void openDir();
     void openIsoWbfs();

--- a/preferencesdialog.cpp
+++ b/preferencesdialog.cpp
@@ -19,6 +19,7 @@
 #include <QDebug>
 #include <QStyleFactory>
 #include "usersettings.h"
+#include "QTemporaryDir"
 
 PreferencesDialog::PreferencesDialog(QWidget *parent) :
     QDialog(parent),
@@ -78,22 +79,40 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
         ui->cacheSizeLabel->setText(QString::number(4) + "GB");
     }
 
-    auto dirname = settings.value("networkCacheDirectory").toString();
-    if (!dirname.isEmpty()) {
-        ui->cacheDirectoryLabel->setText(dirname);
+    auto networkCacheDirName = settings.value("networkCacheDirectory").toString();
+    if (!networkCacheDirName.isEmpty()) {
+        ui->cacheDirectoryLabel->setText(networkCacheDirName);
     } else {
         resetCacheDirectory();
     }
 
+    auto temporaryDirName = settings.value("temporaryDirectory").toString();
+    if (!temporaryDirName.isEmpty()) {
+        ui->temporaryDirectoryLabel->setText(temporaryDirName);
+    } else {
+        resetTemporaryDirectory();
+    }
+
     connect(ui->updateCacheDirectoryButton, &QPushButton::clicked, this, [this](bool){
-        auto dirname = QFileDialog::getExistingDirectory(this, "Set CSMM Network Cache Directory", nullptr);
-        if (!dirname.isEmpty()) {
-            ui->cacheDirectoryLabel->setText(dirname);
+        auto networkCacheDirNname = QFileDialog::getExistingDirectory(this, "Set CSMM Network Cache Directory", nullptr);
+        if (!networkCacheDirNname.isEmpty()) {
+            ui->cacheDirectoryLabel->setText(networkCacheDirNname);
+        }
+    });
+
+    connect(ui->updateTemporaryDirectoryButton, &QPushButton::clicked, this, [this](bool){
+        auto temporaryDirName = QFileDialog::getExistingDirectory(this, "Set CSMM Temporary Directory", nullptr);
+        if (!temporaryDirName.isEmpty()) {
+            ui->temporaryDirectoryLabel->setText(temporaryDirName);
         }
     });
 
     connect(ui->resetCacheDirectoryButton, &QPushButton::clicked, this, [this](bool){
         resetCacheDirectory();
+    });
+
+    connect(ui->resetTemporaryDirectoryButton, &QPushButton::clicked, this, [this](bool){
+        resetTemporaryDirectory();
     });
 
     connect(ui->clearNetworkCacheButton, &QPushButton::clicked, this, [this](bool){
@@ -152,6 +171,9 @@ void PreferencesDialog::accept()
     auto networkCacheDirectory = ui->cacheDirectoryLabel->text();
     settings.setValue("networkCacheDirectory", networkCacheDirectory);
 
+    auto temporaryCacheDirectory = ui->temporaryDirectoryLabel->text();
+    settings.setValue("temporaryDirectory", temporaryCacheDirectory);
+
     QDialog::accept();
 }
 
@@ -174,6 +196,15 @@ void PreferencesDialog::resetCacheDirectory()
     QDir applicationCacheDir(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
     auto defaultNetworkCacheDir = applicationCacheDir.filePath("networkCache");
     ui->cacheDirectoryLabel->setText(defaultNetworkCacheDir);
+}
+
+void PreferencesDialog::resetTemporaryDirectory()
+{
+    QTemporaryDir d;
+    QSettings settings;
+    settings.setValue("temporaryDirectory", d.path());
+    ui->temporaryDirectoryLabel->setText(d.path());
+    d.remove();
 }
 
 // Window Palette

--- a/preferencesdialog.h
+++ b/preferencesdialog.h
@@ -19,6 +19,7 @@ private:
     void enableCacheSettings();
     void disableCacheSettings();
     void resetCacheDirectory();
+    void resetTemporaryDirectory();
     void buildPaletteMenu();
     void paletteActionTriggered();
 private Q_SLOTS:

--- a/preferencesdialog.ui
+++ b/preferencesdialog.ui
@@ -12,8 +12,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>438</width>
-    <height>761</height>
+    <width>422</width>
+    <height>892</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -460,7 +460,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>/home/nikkums/.cache/Custom Street/csmm</string>
+         <string/>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -498,6 +498,69 @@
         </item>
         <item>
          <spacer name="cacheDirectoryRightSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="temporaryDirectoryGroupBox">
+     <property name="title">
+      <string>Temporary Directory</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="temporaryDirectoryLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="resetTemporaryDirectoryButton">
+          <property name="text">
+           <string>Reset</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="updateTemporaryDirectoryButton">
+          <property name="text">
+           <string>Change</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>


### PR DESCRIPTION
Now, users can specify a temporary directory to be used instead of the C: when performing image create operations. You will still need to ensure you have enough disk space, but that space does not need to be on the C drive specifically any longer.