### PR TITLE
JP Wiimmfi text fix

### DIFF
--- a/lib/mods/dolio/wififix.cpp
+++ b/lib/mods/dolio/wififix.cpp
@@ -40,7 +40,7 @@ QMap<QString, UiMessageInterface::SaveMessagesFunction> WifiFix::saveUiMessages(
                     it->second.replace(REG_WIFI_SU, "Wiimmfi\\3\\1\\2");
                 }
                 if (locale == "jp") {
-                    it->second.replace("Ｗｉ－Ｆｉ", "Ｗｉｉｍｍｆｉ", Qt::CaseInsensitive);
+                    it->second.replace("Ｗｉ－Ｆｉ", "Wiimmfi", Qt::CaseInsensitive);
                 }
                 it->second.replace(REG_WIFI, "Wiimmfi");
                 it->second.replace("support.nintendo.com", "https://wiimmfi.de/error", Qt::CaseInsensitive);


### PR DESCRIPTION
changes the Japanese string 'Ｗｉｉｍｍｆｉ' to 'Wiimmfi' - this gets around the issue of the string not rendering correctly in menus and title bars for the Japanese version
![ST7J02_2025-05-01_18-23-22](https://github.com/user-attachments/assets/6b5da972-995e-47b7-a013-e91fb8ced14e)
![ST7J02_2025-05-01_18-23-31](https://github.com/user-attachments/assets/c7020cbe-17bc-43af-b2a3-0f952801323e)
![ST7J02_2025-05-01_19-04-25](https://github.com/user-attachments/assets/75273f17-f79f-488f-9f62-aefb29e79386)
![ST7J02_2025-05-01_19-04-29](https://github.com/user-attachments/assets/aa460f3d-1c78-44d7-b976-188d003acb86)
